### PR TITLE
implemented wrapper for both mpz_powm and mpz_powm_sec from gmp lib.

### DIFF
--- a/src/main/java/com/n1analytics/paillier/PaillierPrivateKey.java
+++ b/src/main/java/com/n1analytics/paillier/PaillierPrivateKey.java
@@ -268,8 +268,8 @@ public final class PaillierPrivateKey {
    * @return the decrypted plaintext.
    */
   public BigInteger raw_decrypt(BigInteger ciphertext){
-    BigInteger decryptedToP = lFunction(BigIntegerUtil.modPow(ciphertext, p.subtract(BigInteger.ONE), pSquared),p).multiply(hp).mod(p);
-    BigInteger decryptedToQ = lFunction(BigIntegerUtil.modPow(ciphertext, q.subtract(BigInteger.ONE), qSquared),q).multiply(hq).mod(q);
+    BigInteger decryptedToP = lFunction(BigIntegerUtil.modPowSecure(ciphertext, p.subtract(BigInteger.ONE), pSquared),p).multiply(hp).mod(p);
+    BigInteger decryptedToQ = lFunction(BigIntegerUtil.modPowSecure(ciphertext, q.subtract(BigInteger.ONE), qSquared),q).multiply(hq).mod(q);
     return crt(decryptedToP, decryptedToQ);
   }
 

--- a/src/main/java/com/n1analytics/paillier/util/BigIntegerUtil.java
+++ b/src/main/java/com/n1analytics/paillier/util/BigIntegerUtil.java
@@ -72,6 +72,25 @@ public class BigIntegerUtil {
   
   /**
    * computes a modular exponentiation. It will call the GMP library, if available on this system.
+   * If GMP is available, it will use 'mpz_powm_sec' which is side channel attack resistant.
+   * Use this function if you want to protect the exponent from side channel attacks.
+   * @param base of the modular exponentiation
+   * @param exponent of the exponentiation
+   * @param modulus
+   * @return (base ^ exponent) mod modulus
+   */
+  public static BigInteger modPowSecure(BigInteger base, BigInteger exponent, BigInteger modulus) {
+    if (USE_GMP) {
+      return exponent.signum() < 0 //Gmp library can't handle negative exponents
+          ? modInverse(Gmp.modPowSecure(base, exponent.negate(), modulus), modulus)
+          : Gmp.modPowSecure(base, exponent, modulus);
+    } else {
+      return base.modPow(exponent, modulus);
+    }
+  }
+  
+  /**
+   * computes a modular exponentiation. It will call the GMP library, if available on this system.
    * This leads to a significant speed-up.
    * @param base of the modular exponentiation
    * @param exponent of the exponentiation
@@ -81,8 +100,8 @@ public class BigIntegerUtil {
   public static BigInteger modPow(BigInteger base, BigInteger exponent, BigInteger modulus) {
     if (USE_GMP) {
       return exponent.signum() < 0 //Gmp library can't handle negative exponents
-          ? modInverse(Gmp.modPowSecure(base, exponent.negate(), modulus), modulus)
-          : Gmp.modPowSecure(base, exponent, modulus);
+          ? modInverse(Gmp.modPowInsecure(base, exponent.negate(), modulus), modulus)
+          : Gmp.modPowInsecure(base, exponent, modulus);
     } else {
       return base.modPow(exponent, modulus);
     }

--- a/src/main/java/com/n1analytics/paillier/util/BigIntegerUtil.java
+++ b/src/main/java/com/n1analytics/paillier/util/BigIntegerUtil.java
@@ -81,10 +81,13 @@ public class BigIntegerUtil {
    */
   public static BigInteger modPowSecure(BigInteger base, BigInteger exponent, BigInteger modulus) {
     if (USE_GMP) {
-      return exponent.signum() < 0 //Gmp library can't handle negative exponents
+      return exponent.signum() < 0 // Gmp library can't handle negative exponents
           ? modInverse(Gmp.modPowSecure(base, exponent.negate(), modulus), modulus)
           : Gmp.modPowSecure(base, exponent, modulus);
     } else {
+      logger.log(Level.WARNING,
+          "Gmp library is not available. Falling back to native Java for modPow. This does not "
+          + "provide protection against timing attacks!");
       return base.modPow(exponent, modulus);
     }
   }


### PR DESCRIPTION
We only use mpz_powm_sec for decryption, as for all other uses of modExp
the exponent is public anyway and therefore does not need protection
from side channel attacks.