### PR TITLE
Allow limited access to underlying number and safety status of EncryptedNumber

### DIFF
--- a/src/main/java/com/n1analytics/paillier/EncryptedNumber.java
+++ b/src/main/java/com/n1analytics/paillier/EncryptedNumber.java
@@ -416,4 +416,28 @@ public final class EncryptedNumber {
             context.equals(o.context) &&
             ciphertext.equals(o.ciphertext));
   }
+
+  /**
+   * Return a byte array representing the underlying raw number.
+   *
+   * WARNING: This method may return unencrypted information! Under no
+   * circumstances should the return value be sent anywhere.
+   *
+   * WARNING: This method is not intended for general use and may be
+   * removed in a future release. Think twice before using it.
+   */
+  public byte[] toByteArrayUnsafe() {
+    return ciphertext.toByteArray();
+  }
+
+  /**
+   * Return true or false according to whether this EncryptedNumber is
+   * safe for transmission.
+   *
+   * WARNING: This method is not intended for general use and may be
+   * removed in a future release. Think twice before using it.
+   */
+  public boolean getIsSafe() {
+    return isSafe;
+  }
 }

--- a/src/main/java/com/n1analytics/paillier/EncryptedNumber.java
+++ b/src/main/java/com/n1analytics/paillier/EncryptedNumber.java
@@ -418,13 +418,15 @@ public final class EncryptedNumber {
   }
 
   /**
-   * Return a byte array representing the underlying raw number.
+   * Return a byte array representing the underlying ciphertext.
    *
    * WARNING: This method may return unencrypted information! Under no
    * circumstances should the return value be sent anywhere.
    *
    * WARNING: This method is not intended for general use and may be
-   * removed in a future release. Think twice before using it.
+   * removed in a future release. Think twice before using it. In
+   * almost all circumstances you should use calculateCiphertext()
+   * instead.
    */
   public byte[] toByteArrayUnsafe() {
     return ciphertext.toByteArray();


### PR DESCRIPTION
This pull request allows the calling context to access the ciphertext of this EncryptedNumber as a byte array. The purpose is to allow passing said array to a native library for processing, thus allowing the use of implementations of arithmetic other than the one provided with the JDK. The changes described are a stop-gap and are expected to be obviated by a future redesign of the EncryptedNumber interface.