### PR TITLE
added switch for verbose jUnit outputs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -79,6 +79,8 @@ testOptions in Test += Tests.Setup(classLoader =>
     .loadClass("org.slf4j.LoggerFactory")
     .getMethod("getLogger", classLoader.loadClass("java.lang.String"))
     .invoke(null, "ROOT"))
+// Turn on verbose outputs for jUnit tests to get around the 10 min Travis timeout
+testOptions += Tests.Argument(TestFrameworks.JUnit, "-v")
 
 jacoco.settings
 


### PR DESCRIPTION
Tests on Travis fail if there is no output for 10 min. Unfortunately, in some cases, our test run longer than that. But with the verbose outputs, we will get around the fixed 10 min limit.
(creates an extra ~6000 lines of log output, though...)