### PR TITLE
Fix junit tests

### DIFF
--- a/src/test/java/com/n1analytics/paillier/PaillierEncodedNumberTest.java
+++ b/src/test/java/com/n1analytics/paillier/PaillierEncodedNumberTest.java
@@ -624,7 +624,7 @@ public class PaillierEncodedNumberTest {
     @Test
     public void testEncodedDecreaseExponentTo0() throws Exception {
       EncodedNumber number1 = context.encode(1.01, Math.pow(1.0, -8));
-      assert -30 < number1.getExponent();
+      assertTrue(-30 < number1.getExponent());
       EncodedNumber number2 = number1.decreaseExponentTo(-30);
 
       if(number1.getExponent() < -30){
@@ -639,7 +639,7 @@ public class PaillierEncodedNumberTest {
     public void testEncodedDecreaseExponentTo1() throws Exception {
       if(conf.signed()) {
         EncodedNumber number1 = context.encode(-1.01, Math.pow(1.0, -8));
-        assert -30 < number1.getExponent();
+        assertTrue(-30 < number1.getExponent());
         EncodedNumber number2 = number1.decreaseExponentTo(-30);
 
         if(number1.getExponent() < -30){
@@ -758,7 +758,7 @@ public class PaillierEncodedNumberTest {
     @Test
     public void testEncodedDecreaseInvalidExponent() throws Exception {
       EncodedNumber enc1 = defaultSignedContext.encode(3.14);
-      assert enc1.getExponent() < -10;
+      assertTrue(enc1.getExponent() < -10);
 
       try {
         enc1.decreaseExponentTo(-10);
@@ -866,7 +866,7 @@ public class PaillierEncodedNumberTest {
 
         double realEps = eps * Math.pow(2.0, (i - 1));
         double val = Math.pow(2.0, i) - realEps;
-        assert val != Math.pow(2.0, i);
+        assertTrue(val != Math.pow(2.0, i));
 
         EncodedNumber enc3 = defaultSignedContext.encode(val);
         EncodedNumber enc4 = defaultSignedContext.encode(val, realEps);

--- a/src/test/java/com/n1analytics/paillier/PaillierEncryptedNumberTest.java
+++ b/src/test/java/com/n1analytics/paillier/PaillierEncryptedNumberTest.java
@@ -66,7 +66,7 @@ public class PaillierEncryptedNumberTest {
     public void testAutomaticPrecision0() throws Exception {
       double eps = Math.ulp(1.0d);
       double onePlusEps = 1.0d + eps;
-      assert onePlusEps > 1;
+      assertTrue(onePlusEps > 1);
 
       EncryptedNumber ciphertext1 = context.encrypt(onePlusEps);
       double decryption1 = privateKey.decrypt(ciphertext1).decodeDouble();
@@ -756,26 +756,22 @@ public class PaillierEncryptedNumberTest {
 
     @Test
     public void testAddWithEncryptedIntAndEncodedNumberDiffExp0() throws Exception {
-      EncryptedNumber ciphertext1 = context.encrypt(15);
-      EncodedNumber encoded2 = context.encode(1.0, 50);
-      assert encoded2.getExponent() > 200;
-      assert ciphertext1.getExponent() > 200;
+      EncryptedNumber ciphertext1 = context.encrypt(1);
+      EncodedNumber encoded1 = context.encode(0.05);
+      assertTrue(ciphertext1.getExponent() > encoded1.getExponent());
 
-      EncodedNumber encoded3 = context.encode(1.0, 200);
-      EncryptedNumber ciphertext3 = ciphertext1.add(encoded3);
-      double decryption = privateKey.decrypt(ciphertext3).decodeDouble();
-      assertEquals(16, (long) decryption);
+      EncryptedNumber ciphertext2 = ciphertext1.add(encoded1);
+      assertEquals(1.05, privateKey.decrypt(ciphertext2).decodeDouble(), EPSILON);
     }
 
     @Test
     public void testAddWithEncryptedIntAndEncodedNumberDiffExp1() throws Exception {
-      EncodedNumber encoded1 = context.encode(1.0, 10);
-      EncryptedNumber ciphertext1 = context.encrypt(context.encode(15.0, 100));
-      assert encoded1.getExponent() == 10;
-      assert ciphertext1.getExponent() == 100;
+      EncryptedNumber ciphertext1 = context.encrypt(0.05);
+      EncodedNumber encoded1 = context.encode(1);
+      assertTrue(ciphertext1.getExponent() < encoded1.getExponent());
 
       EncryptedNumber ciphertext2 = ciphertext1.add(encoded1);
-      assertEquals(16.0, privateKey.decrypt(ciphertext2).decodeDouble(), EPSILON);
+      assertEquals(1.05, privateKey.decrypt(ciphertext2).decodeDouble(), EPSILON);
     }
 
     @Test
@@ -800,10 +796,10 @@ public class PaillierEncryptedNumberTest {
     @Test
     public void testDecreaseExponentTo() throws Exception {
       EncryptedNumber ciphertext1 = context.encrypt(context.encode(1.01, Math.pow(1.0, -8)));
-      assert -30 < ciphertext1.getExponent();
+      assertTrue(-30 < ciphertext1.getExponent());
       EncryptedNumber ciphertext2 = ciphertext1.decreaseExponentTo(-30);
 
-      assert -30 < ciphertext1.getExponent();
+      assertTrue(-30 < ciphertext1.getExponent());
       assertEquals(-30, ciphertext2.getExponent());
       assertEquals(1.01, privateKey.decrypt(ciphertext2).decodeDouble(), Math.pow(1.0, -8));
     }
@@ -1135,7 +1131,7 @@ public class PaillierEncryptedNumberTest {
     @Test
     public void testDecreaseInvalidExponent() throws Exception {
       EncryptedNumber ciphertext = context.encrypt(context.encode(1.01, 1e-8));
-      assert ciphertext.getExponent() < 20;
+      assertTrue(ciphertext.getExponent() < 20);
 
       exception.expect(IllegalArgumentException.class);
       ciphertext.decreaseExponentTo(20);


### PR DESCRIPTION
As pointed out in http://www.yegor256.com/2016/06/17/dont-use-java-assertions.html assertion is not enabled by default and it turned out that there were bugs in the assert statements in the tests. 

This PR addressed the issue by replacing all the assert statements with the appropriate JUnit assertion.